### PR TITLE
ci: automate branded release pages

### DIFF
--- a/.github/releases/v2.0.0-beta.1.env
+++ b/.github/releases/v2.0.0-beta.1.env
@@ -1,0 +1,3 @@
+RELEASE_NAME="CatchBan V2.0 Beta"
+PRERELEASE="false"
+MAKE_LATEST="true"

--- a/.github/releases/v2.0.0-beta.1.md
+++ b/.github/releases/v2.0.0-beta.1.md
@@ -1,0 +1,99 @@
+# CatchBan
+
+捕获灵感，而后掌控。  
+Catch the spark. Command the workflow.
+
+A native macOS creator's media workspace for capture, organize, preview, and lightweight output.  
+面向视频创作者的本地素材库工作台，把采集、整理、预览与轻创作串成一条真正可工作的本地链路。
+
+* * *
+
+# CatchBan V2.0 Beta: The Creator's Workspace Update
+
+> This is the biggest product upgrade in CatchBan so far.  
+> CatchBan has evolved from a single-purpose downloader into a full creator workspace for collecting, organizing, previewing, and preparing media for production.
+>
+> 这是 CatchBan 迄今为止最大的一次系统升级。  
+> 它已经从单一的视频下载工具，升级为面向视频创作者的素材库工作台，让采集、整理、预览与输出进入同一条本地工作流。
+
+* * *
+
+## New in V2.0 Beta (V2.0 Beta 全新升级)
+
+### Creator Library Workspace (创作者素材库工作台)
+- Local-first workspace for downloaded clips, existing local videos, and exported results.
+- 本地优先的素材库工作台，下载内容、本地视频与导出结果都可统一归档。
+- Organize media by project, topic, or stage, and keep everything reusable.
+- 支持按项目、主题与阶段管理素材，让复用更顺畅。
+
+### 4K Capture & Browser-Assisted Verification (4K 采集与浏览器辅助验证)
+- Supports 4K video downloads where available, with more flexible quality selection.
+- 支持 4K 高清视频下载，并提供更灵活的清晰度选择。
+- Built-in browser-assisted verification helps handle more complex capture scenarios.
+- 内置浏览器辅助验证能力，可应对更复杂的采集场景。
+
+### Native Preview & Frame Review (原生预览与逐帧检视)
+- Preview clips directly inside the workspace without constant switching between Finder and external players.
+- 可直接在工作台中预览素材，减少 Finder 与外部播放器之间的来回切换。
+- Improved frame-by-frame review and key frame inspection for faster shot selection.
+- 优化逐帧查看与关键帧检视链路，筛镜头、挑素材更高效。
+
+### Creative Toolbox (创作工具箱)
+- Includes H.264 conversion, clip export, GIF export, frame capture, audio extraction, and batch thumbnail generation.
+- 内置 H.264 转码、片段导出、GIF 导出、关键帧抓取、音频提取与批量缩略图能力。
+- Turns downloaded references into usable creative assets faster.
+- 让参考素材更快进入“可创作状态”。
+
+### Workflow Intelligence (工作流智能整理)
+- Adds global search, recent items, Inbox, duplicate candidates, and same-source grouping suggestions.
+- 新增全库搜索、最近记录、稍后整理（Inbox）、重复候选与同来源归档建议。
+- Designed for creators who manage large volumes of reference material every day.
+- 更适合需要长期管理大量素材的创作者工作流。
+
+### Post-Production Ready (无缝衔接后期)
+- Selected clips can flow directly into Premiere Pro, DaVinci Resolve, Final Cut Pro, and other editing tools.
+- 选定素材可直接衔接 Premiere Pro、DaVinci Resolve、Final Cut Pro 等后期流程。
+- Shortens the distance from discovery to edit.
+- 明显缩短从“发现参考”到“进入剪辑”的路径。
+
+* * *
+
+## Installation (安装说明)
+
+1. Download the latest `.dmg` below or from Releases.
+2. Drag `CatchBan.app` to `Applications`.
+3. If macOS shows "App is Damaged" or blocks the app:
+   - Open `System Settings -> Privacy & Security`
+   - Click `Open Anyway` / `仍要打开`
+
+如遇到 macOS 安全拦截，请前往：  
+`系统设置 -> 隐私与安全性 -> 仍要打开`
+
+* * *
+
+## Notes (说明)
+
+- Beta is currently free to use.
+- 当前 Beta 版本免费开放。
+- No account or subscription is required.
+- 无需注册账号，无需订阅即可使用。
+- Existing local library assets and structure can continue into future versions.
+- 现有本地素材库结构与资产可延续到后续版本。
+
+* * *
+
+## Disclaimer (免责声明)
+
+This software is intended for lawful reference collection, technical research, and personal archiving only.  
+Please do not use it to acquire or distribute copyrighted content without permission.
+
+本软件仅用于合法前提下的参考素材采集、技术研究与个人归档。  
+请勿在未获授权的情况下采集、传播或使用受版权保护的内容。
+
+* * *
+
+GitHub: https://github.com/Banansky-Studio/CatchBan  
+Issues / Feedback: https://github.com/Banansky-Studio/CatchBan/issues
+
+© 2026 Banansky Studio. All rights reserved.  
+Catch the spark. Command the workflow.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: Create Release Page
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag, for example: v1.5.1"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release metadata
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+
+          VERSION="${TAG#v}"
+          RELEASE_DIR=".github/releases"
+          ENV_FILE="${RELEASE_DIR}/${TAG}.env"
+          BODY_FILE="${RELEASE_DIR}/${TAG}.md"
+          RELEASE_NAME=""
+          PRERELEASE="false"
+          MAKE_LATEST="legacy"
+          HAS_BODY="false"
+
+          if [[ -f "${ENV_FILE}" ]]; then
+            set -a
+            # shellcheck disable=SC1090
+            source "${ENV_FILE}"
+            set +a
+          fi
+
+          if [[ -z "${RELEASE_NAME}" ]]; then
+            if [[ "${VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)-beta(\.[0-9]+)?$ ]]; then
+              RELEASE_NAME="CatchBan V${BASH_REMATCH[1]}.${BASH_REMATCH[2]} Beta"
+            elif [[ "${VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)-rc(\.[0-9]+)?$ ]]; then
+              RELEASE_NAME="CatchBan V${BASH_REMATCH[1]}.${BASH_REMATCH[2]} RC"
+            elif [[ "${VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+              RELEASE_NAME="CatchBan V${VERSION}"
+            else
+              RELEASE_NAME="CatchBan ${TAG}"
+            fi
+          fi
+
+          if [[ -f "${BODY_FILE}" ]]; then
+            HAS_BODY="true"
+          fi
+
+          {
+            echo "tag=${TAG}"
+            echo "version=${VERSION}"
+            echo "release_name=${RELEASE_NAME}"
+            echo "body_path=${BODY_FILE}"
+            echo "prerelease=${PRERELEASE}"
+            echo "make_latest=${MAKE_LATEST}"
+            echo "has_body=${HAS_BODY}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Resolved tag: ${TAG}"
+          echo "Resolved release name: ${RELEASE_NAME}"
+          echo "Resolved prerelease: ${PRERELEASE}"
+          echo "Resolved make_latest: ${MAKE_LATEST}"
+          echo "Resolved body file: ${BODY_FILE}"
+
+      - name: Create templated GitHub Release
+        if: ${{ steps.release.outputs.has_body == "true" }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.release.outputs.tag }}
+          name: ${{ steps.release.outputs.release_name }}
+          target_commitish: ${{ github.sha }}
+          body_path: ${{ steps.release.outputs.body_path }}
+          prerelease: ${{ steps.release.outputs.prerelease }}
+          make_latest: ${{ steps.release.outputs.make_latest }}
+
+      - name: Create generated GitHub Release
+        if: ${{ steps.release.outputs.has_body != "true" }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.release.outputs.tag }}
+          name: ${{ steps.release.outputs.release_name }}
+          target_commitish: ${{ github.sha }}
+          generate_release_notes: true
+          prerelease: ${{ steps.release.outputs.prerelease }}
+          make_latest: ${{ steps.release.outputs.make_latest }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,110 @@
+# CatchBan Release Workflow
+
+This repo now automates GitHub Release page creation only.  
+App build, DMG packaging, and the readme/PDF inside the DMG remain local (manual).
+
+## 1) Local release build (manual)
+
+1. Validate runtime architecture coverage before archive:
+
+```bash
+scripts/validate_release_architectures.sh
+```
+
+2. Run explicit dual-architecture compile checks (arm64 + x86_64):
+
+```bash
+scripts/verify_dual_arch_build.sh
+```
+
+This step now enforces architecture isolation automatically via:
+
+```bash
+scripts/enforce_runtime_arch_isolation.sh
+```
+
+3. Build and verify the new version in Xcode.
+
+4. (Recommended) Validate the built `.app` again before DMG packaging:
+
+```bash
+scripts/validate_release_architectures.sh --bundle "/path/to/CatchBan.app"
+```
+
+5. Package your final `.dmg` locally (including your readme/PDF).
+
+## 2) Prepare release metadata in repo
+
+Create versioned release files before tagging:
+
+- `.github/releases/<tag>.env`
+- `.github/releases/<tag>.md`
+
+Example for `v2.0.0-beta.1`:
+
+```bash
+cat .github/releases/v2.0.0-beta.1.env
+cat .github/releases/v2.0.0-beta.1.md
+```
+
+The `.env` file controls release metadata:
+
+```bash
+RELEASE_NAME="CatchBan V2.0 Beta"
+PRERELEASE="false"
+MAKE_LATEST="true"
+```
+
+Supported keys:
+
+- `RELEASE_NAME`: Human-facing release title.
+- `PRERELEASE`: `true` or `false`.
+- `MAKE_LATEST`: `true`, `false`, or `legacy`.
+
+If `.github/releases/<tag>.md` exists, the workflow uses that bilingual Markdown as the release body.  
+If it does not exist, the workflow falls back to GitHub-generated release notes.
+
+## 3) Create Release page automatically
+
+### Option A: Tag-driven (recommended)
+
+```bash
+git tag -a v2.0.0-beta.1 -m "CatchBan V2.0 Beta"
+git push origin v2.0.0-beta.1
+```
+
+What automation does:
+
+- Creates or updates `releases/tag/v2.0.0-beta.1`
+- Uses `.github/releases/v2.0.0-beta.1.env` for release title and publish flags
+- Uses `.github/releases/v2.0.0-beta.1.md` for the final release body
+- Falls back to GitHub-generated notes if no versioned Markdown body exists
+- Does not upload any assets
+
+### Option B: Manual trigger (Actions UI)
+
+Actions -> `Create Release Page` -> `Run workflow` -> input tag (for example `v2.0.0-beta.1`)
+
+## 4) Upload DMG manually
+
+After the release page exists, upload your local `.dmg` by either:
+
+- GitHub web UI (Release page -> `Attach binaries`)
+- CLI:
+
+```bash
+gh release upload v2.0.0-beta.1 /path/to/CatchBan.dmg --clobber
+```
+
+Optional checksum upload:
+
+```bash
+shasum -a 256 /path/to/CatchBan.dmg > /path/to/CatchBan.dmg.sha256
+gh release upload v2.0.0-beta.1 /path/to/CatchBan.dmg.sha256 --clobber
+```
+
+## 5) Fallback behavior
+
+- The release workflow prefers versioned `.github/releases/<tag>.md` files when present.
+- If no versioned Markdown body exists, the workflow falls back to GitHub-generated release notes.
+- This keeps release pages brand-safe and bilingual while preserving a fallback path for technical releases.


### PR DESCRIPTION
## Summary

- add version-based GitHub Release templates
- automate Release title, body, prerelease, and latest flags
- add the bilingual release template for `v2.0.0-beta.1`
- document the updated release workflow

## Why

This lets CatchBan publish branded bilingual Release pages automatically instead of relying on default generated notes.
